### PR TITLE
Add endpoint to create short urls

### DIFF
--- a/app/controllers/shorten_controller.rb
+++ b/app/controllers/shorten_controller.rb
@@ -1,0 +1,21 @@
+class ShortenController < ApplicationController
+  def create
+    short_url = ShortUrl.new(url: short_url_params[:url])
+    if short_url.save
+      url = redirect_to_short_url(short_url.encoded_id)
+      render json: { short_url: url }, status: :created
+    else
+      render json: { errors: short_url.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def short_url_params
+    json = JSON.parse(request.body.read)
+    ActionController::Parameters
+                      .new(json)
+                      .require(:short_url)
+                      .permit(:url)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  get '/:id' => 'redirects#show'
+  resources :shorten, only: :create
+  get '/:id' => 'redirects#show', as: :redirect_to_short
 end

--- a/spec/controllers/shorten_controller_spec.rb
+++ b/spec/controllers/shorten_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ShortenController, type: :controller do
+  describe 'POST #create' do
+    let(:payload) { { url: 'https://foo.bar' } }
+    let(:json) { { short_url: payload }.to_json }
+
+    context 'with valid url' do
+      it 'create short url on database' do
+        expect {
+          post :create, body: json, format: :json
+        }.to change(ShortUrl, :count).by(1) 
+      end
+  
+      it 'return http status created' do
+        post :create, body: json, format: :json
+        expect(response).to have_http_status(:created)
+      end
+  
+      it 'return short url on json' do
+        post :create, body: json, format: :json
+        parsed_json = JSON.parse(response.body)
+        url = redirect_to_short_url(ShortUrl.last.encoded_id)
+        expect(parsed_json["short_url"]).to eq(url)
+      end
+    end
+
+    context 'with invalid url' do
+      let(:payload) { { url: '' } }
+      it 'return http status unprocessable entity' do
+        post :create, body: json, format: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'return errors on json' do
+        post :create, body: json, format: :json
+        parsed_json = JSON.parse(response.body)
+        expect(parsed_json["errors"]).to_not be_empty
+      end
+
+      it 'do not save url on database' do
+        expect {
+          post :create, body: json, format: :json
+        }.to_not change(ShortUrl, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This endpoint receives one json, save short url on database and return
short version in response.

https://trello.com/c/AHMYgcz6/16-create-endpoint-to-shorten-urls